### PR TITLE
feat: add getOrdersByEmail endpoint

### DIFF
--- a/Aesth.Api/Program.cs
+++ b/Aesth.Api/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddScoped<LoginUseCase>();
 builder.Services.AddScoped<RegisterUseCase>();
 builder.Services.AddScoped<CreateCheckoutSessionUseCase>();
 builder.Services.AddScoped<CreateOrderUseCase>();
+builder.Services.AddScoped<GetOrdersByEmailUseCase>();
 
 builder.Services.AddScoped<IJwtService, JwtService>();
 builder.Services.AddScoped<ICheckoutService, StripeCheckoutService>();

--- a/Aesth.Application/Interfaces/IOrderRepository.cs
+++ b/Aesth.Application/Interfaces/IOrderRepository.cs
@@ -9,5 +9,6 @@ namespace Aesth.Application.Interfaces
     public interface IOrderRepository
     {
         Task SaveAsync(Order order);
+        Task<List<Order>> GetOrdersByEmailAsync(string email);
     }
 }

--- a/Aesth.Application/UseCases/Order/CreateOrderUseCase.cs
+++ b/Aesth.Application/UseCases/Order/CreateOrderUseCase.cs
@@ -9,42 +9,42 @@ using Aesth.Application.Interfaces;
 namespace Aesth.Application.UseCases.Order
 {
     public class CreateOrderUseCase
-{
-    private readonly IOrderRepository _orderRepository;
-
-    public CreateOrderUseCase(IOrderRepository orderRepository)
     {
-        _orderRepository = orderRepository;
-    }
+        private readonly IOrderRepository _orderRepository;
 
-    public async Task SaveOrderAsync(OrderDto dto)
-    {
-        var order = new Domain.Models.Order
+        public CreateOrderUseCase(IOrderRepository orderRepository)
         {
-            Id = Guid.NewGuid(),
-            StripeSessionId = dto.StripeSessionId,
-            Email = dto.Email,
-            CreatedAt = DateTime.UtcNow,
-            Address = new Address
-            {
-                Line1 = dto.ShippingAddress.Line1,
-                Line2 = dto.ShippingAddress.Line2,
-                PostalCode = dto.ShippingAddress.PostalCode,
-                City = dto.ShippingAddress.City,
-                Country = dto.ShippingAddress.Country,
-            },
-            Items = dto.Items.Select(i => new OrderItem
-            {
-                Name = i.Name,
-                Size = i.Size,
-                Price = i.Price,
-                Quantity = i.Quantity,
-                Image = i.Image
-            }).ToList()
-        };
+            _orderRepository = orderRepository;
+        }
 
-        await _orderRepository.SaveAsync(order);
+        public async Task SaveOrderAsync(OrderDto dto)
+        {
+            var order = new Domain.Models.Order
+            {
+                Id = Guid.NewGuid(),
+                StripeSessionId = dto.StripeSessionId,
+                Email = dto.Email,
+                CreatedAt = DateTime.UtcNow,
+                Address = new Address
+                {
+                    Line1 = dto.ShippingAddress.Line1,
+                    Line2 = dto.ShippingAddress.Line2,
+                    PostalCode = dto.ShippingAddress.PostalCode,
+                    City = dto.ShippingAddress.City,
+                    Country = dto.ShippingAddress.Country,
+                },
+                Items = dto.Items.Select(i => new OrderItem
+                {
+                    Name = i.Name,
+                    Size = i.Size,
+                    Price = i.Price,
+                    Quantity = i.Quantity,
+                    Image = i.Image
+                }).ToList()
+            };
+
+            await _orderRepository.SaveAsync(order);
+        }
     }
-}
 
 }

--- a/Aesth.Application/UseCases/Order/GetOrdersByEmailUseCase.cs
+++ b/Aesth.Application/UseCases/Order/GetOrdersByEmailUseCase.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Aesth.Application.DTOs.Checkout;
+using Aesth.Application.Interfaces;
+
+namespace Aesth.Application.UseCases.Order
+{
+    public class GetOrdersByEmailUseCase
+    {
+        private readonly IOrderRepository _orderRepository;
+
+        public GetOrdersByEmailUseCase(IOrderRepository orderRepository)
+        {
+            _orderRepository = orderRepository;
+        }
+
+        public async Task<List<OrderDto>> GetOrdersByEmailAsync(string email)
+        {
+            var orders = await _orderRepository.GetOrdersByEmailAsync(email);
+            return orders.Select(o => new OrderDto
+            {
+                StripeSessionId = o.StripeSessionId,
+                Email = o.Email,
+                ShippingAddress = o.Address == null ? null : new AddressDto
+                {
+                    Line1 = o.Address.Line1,
+                    Line2 = o.Address.Line2,
+                    PostalCode = o.Address.PostalCode,
+                    City = o.Address.City,
+                    Country = o.Address.Country
+                },
+                Items = o.Items?.Select(i => new OrderItemDto
+                {
+                    Name = i.Name,
+                    Size = i.Size,
+                    Price = i.Price,
+                    Quantity = i.Quantity,
+                    Image = i.Image
+                }).ToList()
+            }).ToList();
+        }
+
+    }
+}

--- a/Aesth.Infrastructure/Persistence/DbContexts/AppDbContextFactory.cs
+++ b/Aesth.Infrastructure/Persistence/DbContexts/AppDbContextFactory.cs
@@ -15,7 +15,7 @@ namespace Aesth.Infrastructure.Persistence.DbContexts
         {
             var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
 
-            optionsBuilder.UseNpgsql("Host=db.apsnxcnzwhygiruighvy.supabase.co;Port=6543;Database=postgres;Username=postgres;Password=EV6n6OYL35j5uZFh;SSL Mode=Require;Trust Server Certificate=true;Timeout=15;Command Timeout=30;Pooling=true;Maximum Pool Size=100");
+            optionsBuilder.UseNpgsql("Host=localhost;Database=TuBase;Username=tu_usuario;Password=tu_password");
 
             return new AppDbContext(optionsBuilder.Options);
         }

--- a/Aesth.Infrastructure/Persistence/Entities/order_item.cs
+++ b/Aesth.Infrastructure/Persistence/Entities/order_item.cs
@@ -13,5 +13,8 @@ namespace Aesth.Infrastructure.Persistence.Entities
         public long price { get; set; }
         public int quantity { get; set; }
         public string? image { get; set; }
+
+        public Guid orderid { get; set; }
+        public order? Order { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
Integrated GetOrdersByEmail endpoint to retrieve user orders with associated items and shipping address.

## Changes Made
Added repository method to query orders by email, including related order items and shipping address via EF Core Include.
Mapped database entities (order, order_item, order_address) to domain models (Order, OrderItem, Address).
Implemented use case GetOrdersByEmailUseCase for business logic to fetch and map orders.
Created API endpoint OrderController.GetOrdersByEmail to expose orders data filtered by customer email.